### PR TITLE
care utf8 flags

### DIFF
--- a/Discount.xs
+++ b/Discount.xs
@@ -37,10 +37,12 @@ BOOT:
     newCONSTSUB(stash, "MKD_EXTRA_FOOTNOTE", newSViv(MKD_EXTRA_FOOTNOTE));
 
 SV *
-TextMarkdown__markdown(text, flags)
-        char *text;
+TextMarkdown__markdown(sv_str, flags)
+        SV *sv_str
         int flags;
     PREINIT:
+        bool is_utf8 = SvUTF8(sv_str);
+        char *text = SvPV_nolen(sv_str);
         SV* r = &PL_sv_undef;
         char *html = NULL;
         int szhtml;
@@ -62,6 +64,9 @@ TextMarkdown__markdown(text, flags)
 
         r = newSVpvn(html, szhtml);
         sv_catpv(r, "\n");
+        if (is_utf8) {
+            sv_utf8_decode(r);
+        }
 
         mkd_cleanup(doc);
         RETVAL = r;

--- a/t/12.utf8.t
+++ b/t/12.utf8.t
@@ -1,0 +1,20 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More tests => 4;
+use Text::Markdown::Discount;
+
+{
+    my $perl_string = '# あ';
+    my $html = Text::Markdown::Discount::markdown($perl_string);
+    like $html, qr!<h1>あ</h1>!;
+    ok utf8::is_utf8($html);
+}
+
+{
+    no utf8;
+    my $byte = '# あ';
+    my $html = Text::Markdown::Discount::markdown($byte);
+    like $html, qr!<h1>あ</h1>!;
+    ok !utf8::is_utf8($html);
+}


### PR DESCRIPTION
In general, most of `markdown` function returns perl string (utf8 flaggd) if
parameter is perl string (eg. Text::Markdown Text::MultiMarkdown), 
but current implemention of Text::Markdown::Discount is not.

In this patch cares the parameter is utf8 flagged or not.
