### PR TITLE
Use <br /> instead of <br/>

### DIFF
--- a/discount/generate.c
+++ b/discount/generate.c
@@ -1243,7 +1243,7 @@ text(MMIOT *f)
 	switch (c) {
 	case 0:     break;
 
-	case 3:     Qstring(tag_text(f) ? "  " : "<br/>", f);
+	case 3:     Qstring(tag_text(f) ? "  " : "<br />", f);
 		    break;
 
 	case '>':   if ( tag_text(f) )

--- a/discount/tests/peculiarities.t
+++ b/discount/tests/peculiarities.t
@@ -64,13 +64,13 @@ That goes over multiple lines</p>
 
 <h2>AND THEN A HEADER</h2>'
 
-try 'forcing a <br/>' 'this  
-is' '<p>this<br/>
+try 'forcing a <br />' 'this  
+is' '<p>this<br />
 is</p>'
 
 try 'trimming single spaces' 'this ' '<p>this</p>'
-try -fnohtml 'markdown <br/> with -fnohtml' 'foo  
-is'  '<p>foo<br/>
+try -fnohtml 'markdown <br /> with -fnohtml' 'foo  
+is'  '<p>foo<br />
 is</p>'
 
 summary $0

--- a/discount/tests/schiraldi.t
+++ b/discount/tests/schiraldi.t
@@ -6,7 +6,7 @@ rc=0
 MARKDOWN_FLAGS=
 
 try -fnohtml 'breaks with -fnohtml' 'foo  
-bar' '<p>foo<br/>
+bar' '<p>foo<br />
 bar</p>'
 
 try 'links with trailing \)' \

--- a/discount/tests/snakepit.t
+++ b/discount/tests/snakepit.t
@@ -23,7 +23,7 @@ try '<unfinished &<tags> (2)' \
 '<foo [bar](foo)  &<s>hi</s>' \
 '<p><foo [bar](foo)  &<s>hi</s></p>'
 
-try 'paragraph <br/> oddity' 'EOF  ' '<p>EOF</p>'
+try 'paragraph <br /> oddity' 'EOF  ' '<p>EOF</p>'
     
 summary $0
 exit $rc


### PR DESCRIPTION
According to https://www.w3.org/TR/xhtml1/#C_2
>C.2. Empty Elements
Include a space before the trailing / and > of empty elements, e.g. `<br />`, `<hr />` and `<img src="karen.jpg" alt="Karen" />`. Also, use the minimized tag syntax for empty elements, e.g. `<br />`, as the alternative syntax `<br></br>` allowed by XML gives uncertain results in many existing user agents.