### PR TITLE
Compile under clang 12 in osx

### DIFF
--- a/discount/configure.inc
+++ b/discount/configure.inc
@@ -879,10 +879,11 @@ AC_SCALAR_TYPES () {
 	TLOG " (defined in WinDef.h)"
 	return 0
     fi
-	
+
     cat > ngc$$.c << EOF
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 
 int pound_define = 1;
 
@@ -1053,6 +1054,7 @@ AC_CHECK_FLOCK() {
 #include <sys/file.h>
 #include <sys/types.h>
 #include <fcntl.h>
+#include <stdlib.h>
 
 main()
 {

--- a/discount/configure.sh
+++ b/discount/configure.sh
@@ -97,9 +97,9 @@ else
     AC_DEFINE 'INITRNG(x)' '(void)1'
 fi
 
-if AC_CHECK_FUNCS 'bzero((char*)0,0)'; then
+if AC_CHECK_FUNCS 'bzero((char*)0,0)' strings.h; then
     : # Yay
-elif AC_CHECK_FUNCS 'memset((char*)0,0,0)'; then
+elif AC_CHECK_FUNCS 'memset((char*)0,0,0)' strings.h; then
     AC_DEFINE 'bzero(p,s)' 'memset(p,s,0)'
 else
     AC_FAIL "$TARGET requires bzero or memset"


### PR DESCRIPTION
WORD & DWORD are defined in stdlib.h, and bzero & memset are in strings.h; not including those breaks compilation.