### PR TITLE
support fenced code block and definition list

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -61,7 +61,7 @@ sub MY::postamble {
     return sprintf('
 $(MYEXTLIB):
 	%s
-', qq{( cd $extdir; CC='cc -fPIC' sh configure.sh; make )\n});
+', qq{( cd $extdir; CC='cc -fPIC' sh configure.sh --with-fenced-code --with-dl=both; make )\n});
 }
 
 WriteMakefile(


### PR DESCRIPTION
by adding configure option "--with-fenced-code --with-dl=both"

Especially for the fenced code block, it has become popular enough, partly due to GitHub, that I think it should be supported by default.