### PR TITLE
Add missing URL in POD

### DIFF
--- a/lib/Text/Markdown/Discount.pm
+++ b/lib/Text/Markdown/Discount.pm
@@ -78,6 +78,7 @@ It passes Gruber's Markdown testsuite.
 
 Given that the performance of Discount, Text::Markdown::Discount processes
 markdown formatted text quickly and passes the Markdown test suite at
+L<http://daringfireball.net/projects/downloads/MarkdownTest_1.0.zip>
 
 The interface of the C<markdown()> function in this module
 is not compatible with the C<markdown()> function in L<Text::Markdown>.


### PR DESCRIPTION
Assuming that you wanted to link to http://daringfireball.net/projects/downloads/MarkdownTest_1.0.zip, since that's what's listed at https://github.com/Orc/discount/blob/main/README